### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -1,5 +1,7 @@
 ---
 name: "✅ Zsh"
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/z-shell/zbrowse/security/code-scanning/6](https://github.com/z-shell/zbrowse/security/code-scanning/6)

In general, the fix is to explicitly declare the minimal `GITHUB_TOKEN` permissions required by this workflow, instead of relying on repository/organization defaults. Because both jobs only need to read repository contents (for `actions/checkout`) and do not perform any write operations via the GitHub API, we can safely set `contents: read` at the workflow level. This will apply to both jobs and documents that the workflow requires only read access.

The best fix with no functional change is to add a root-level `permissions:` block just after the `name:` (or after the `on:` section, but root-level) in `.github/workflows/zsh-n.yml`. For this workflow, a minimal and sufficient block is:
```yaml
permissions:
  contents: read
```
This restricts the `GITHUB_TOKEN` to read-only for repository contents, which still allows `actions/checkout` to function. No other permissions (such as `pull-requests` or `issues`) are needed because the workflow does not interact with those resources. No additional imports or methods are required; it is a pure YAML configuration change.

Concretely, in `.github/workflows/zsh-n.yml`, insert the `permissions` block near the top of the file, without modifying any of the existing jobs or steps. All existing behavior (checking out code, finding `.zsh` files, running `zsh -n` and `zcompile`) will continue to work unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
